### PR TITLE
Fix failure when reading star-files without rln-header

### DIFF
--- a/pyem/star.py
+++ b/pyem/star.py
@@ -227,7 +227,7 @@ def parse_star(starfile, keep_index=False, augment=False):
     ln = 0
     with open(starfile, 'rU') as f:
         for l in f:
-            if l.startswith("_rln"):
+            if l.startswith("_"):
                 foundheader = True
                 lastheader = True
                 if keep_index:


### PR DESCRIPTION
pyem.star.parse_star fails when reading STAR-files that have non-Relion headers. This provides an easy fix.