### PR TITLE
Shorten float number format in star output

### DIFF
--- a/pyem/star.py
+++ b/pyem/star.py
@@ -296,7 +296,7 @@ def write_star(starfile, df, resort_fields=True, simplify=True):
             line = name + " \n"
             line = line if line.startswith('_') else '_' + line
             f.write(line)
-    df.to_csv(starfile, mode='a', sep=' ', header=False, index=False)
+    df.to_csv(starfile, mode='a', sep=' ', header=False, index=False, float_format='%.6f')
 
 
 def transform_star(df, r, t=None, inplace=False, rots=None, invert=False, rotate=True, adjust_defocus=False):


### PR DESCRIPTION
6-digit decimal is relion format default and should have sufficient accuracy for later manipulations. Output the full digits of a float64 gives a lot of numbers like "3.9668620000000003" from an original value of "3.966862", which increases star file size and makes the file harder for "manual" examination.