### PR TITLE
Bug in to_micrographs (star.py) and syntax warning in mrc.py

### DIFF
--- a/pyem/mrc.py
+++ b/pyem/mrc.py
@@ -54,7 +54,7 @@ def mrc_header_complete(data, psz=1.0, origin=None):
     header_f[54] = np.sqrt(np.mean(data**2))
     if origin is None:
         header_f[49:52] = (0, 0, 0)
-    elif origin is "center":
+    elif origin == "center":
         header_f[49:52] = psz * header[:3] / 2
     else:
         header_f[49:52] = origin

--- a/pyem/star.py
+++ b/pyem/star.py
@@ -228,7 +228,7 @@ def to_micrographs(df):
     df = mu[[c for c in Relion.CTF_PARAMS + Relion.MICROSCOPE_PARAMS +
              [Relion.MICROGRAPH_NAME, Relion.OPTICSGROUP] if c in mu]].reset_index()
     if Relion.OPTICSGROUP in df:
-        df = df.astypes(Relion.DATATYPES)
+        df = df.astype(Relion.DATATYPES)
     return df
 
 


### PR DESCRIPTION
There was a small typo bug in star.py. DataFrames don't have a `astypes` function, only `astype`

Additionally, there was a syntax warning from `mrc.py:57`, the `is` operator should not be used here, see https://bugs.python.org/issue34850