### PR TITLE
Add parsing for filament id

### DIFF
--- a/pyem/metadata.py
+++ b/pyem/metadata.py
@@ -363,9 +363,9 @@ def cryosparc_2_cs_filament_parameters(cs, df=None):
     log = logging.getLogger('root')
     if df is None:
         df = pd.DataFrame()
-    if "filament/filament_uid" in cs.dtype.names:
-        log.info("Copying helical filament ID")
-        df[star.Relion.HELICALTUBEID] = cs["filament/filament_uid"]
+    if 'filament/filament_pose' in cs.dtype.names:
+        log.info('Copying filament pose')
+        df[star.Relion.ANGLEPSI] = -cs['filament/filament_pose'] + np.pi/2
     return df
 
 
@@ -405,7 +405,8 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
                u'location/center_y_frac': None,
                u'location/micrograph_path': star.Relion.MICROGRAPH_NAME,
                u'location/micrograph_shape': None,
-               u'filament/filament_uid': star.Relion.HELICALTUBEID}
+               u'filament/filament_uid': star.Relion.HELICALTUBEID,
+               u'filament/filament_pose': None}
     log = logging.getLogger('root')
     log.debug("Reading primary file")
     cs = csfile if type(csfile) is np.ndarray else np.load(csfile)
@@ -428,7 +429,7 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
                 ptdf = cryosparc_2_cs_particle_locations(pt, ptdf, swapxy=swapxy, invertx=invertx, inverty=inverty)
                 # ptdf = cryosparc_2_cs_model_parameters(pt, ptdf, minphic=minphic)
                 ptdf = cryosparc_2_cs_array_parameters(pt, ptdf)
-                ptdf = cryosparc_2_cs_filament_parameters(cs, ptdf)
+                ptdf = cryosparc_2_cs_filament_parameters(pt, ptdf)
                 key = star.UCSF.UID
                 log.info("Trying to merge: %s" % ", ".join(names))
                 fields = [c for c in ptdf.columns if c not in df.columns]

--- a/pyem/metadata.py
+++ b/pyem/metadata.py
@@ -404,7 +404,8 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
                u'location/center_x_frac': None,
                u'location/center_y_frac': None,
                u'location/micrograph_path': star.Relion.MICROGRAPH_NAME,
-               u'location/micrograph_shape': None}
+               u'location/micrograph_shape': None,
+               u'filament/filament_uid': star.Relion.HELICALTUBEID}
     log = logging.getLogger('root')
     log.debug("Reading primary file")
     cs = csfile if type(csfile) is np.ndarray else np.load(csfile)
@@ -427,6 +428,7 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
                 ptdf = cryosparc_2_cs_particle_locations(pt, ptdf, swapxy=swapxy, invertx=invertx, inverty=inverty)
                 # ptdf = cryosparc_2_cs_model_parameters(pt, ptdf, minphic=minphic)
                 ptdf = cryosparc_2_cs_array_parameters(pt, ptdf)
+                ptdf = cryosparc_2_cs_filament_parameters(cs, ptdf)
                 key = star.UCSF.UID
                 log.info("Trying to merge: %s" % ", ".join(names))
                 fields = [c for c in ptdf.columns if c not in df.columns]

--- a/pyem/metadata.py
+++ b/pyem/metadata.py
@@ -60,7 +60,7 @@ def parse_f9_par(fn):
                            "MAG", "FILM", "DF1", "DF2", "ANGAST",
                            "OCC", "LogP", "SIGMA", "SCORE", "CHANGE"]
                 break
-                
+
             ln += 1
 
     if skip == 0:
@@ -359,6 +359,16 @@ def cryosparc_2_cs_array_parameters(cs, df=None):
     return df
 
 
+def cryosparc_2_cs_filament_parameters(cs, df=None):
+    log = logging.getLogger('root')
+    if df is None:
+        df = pd.DataFrame()
+    if "filament/filament_uid" in cs.dtype.names:
+        log.info("Copying helical filament ID")
+        df[star.Relion.HELICALTUBEID] = cs["filament/filament_uid"]
+    return df
+
+
 def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
                          swapxy=False, invertx=False, inverty=False):
     micrograph = {u'uid': star.UCSF.UID,
@@ -402,6 +412,7 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
     df = cryosparc_2_cs_particle_locations(cs, df, swapxy=swapxy, invertx=invertx, inverty=inverty)
     df = cryosparc_2_cs_model_parameters(cs, df, minphic=minphic)
     df = cryosparc_2_cs_array_parameters(cs, df)
+    df = cryosparc_2_cs_filament_parameters(cs, df)
     if passthroughs is not None:
         for passthrough in passthroughs:
             if type(passthrough) is np.ndarray:

--- a/pyem/star.py
+++ b/pyem/star.py
@@ -84,6 +84,7 @@ class Relion:
     MICROGRAPHPIXELSIZE = "rlnMicrographPixelSize"
     MICROGRAPHORIGINALPIXELSIZE = "rlnMicrographOriginalPixelSize"
     MTFFILENAME = "rlnMtfFileName"
+    HELICALTUBEID = "rlnHelicalTubeID"
 
     # Field lists.
     COORDS = [COORDX, COORDY]
@@ -460,7 +461,7 @@ def write_star(starfile, df, resort_fields=True, resort_records=False, simplify=
         df = sort_records(df, inplace=True)
     if simplify and len([c for c in df.columns if "ucsf" in c or "eman" in c]) > 0:
         df = simplify_star_ucsf(df)
-    
+
     if optics:
         if Relion.OPTICSGROUP not in df:
             df[Relion.OPTICSGROUP] = 1


### PR DESCRIPTION
Hi all! I've been playing around with `pyem` over at [cs2star](https://github.com/brisvag/cs2star/) to get a quick-and-dirty cryosparc-to-relion conversion script. A colleague wanted access to the filament-id from cryosparc, and I thought the best way would be to contribute to the upstream parser in this repo.

This PR adds parsing of filament-id in cryosparc, for conversion to RELION star files. As far as I can tell it works, but let me know if I'm missing something or this isn't the right approach. Cheers!