### PR TITLE
Fix star2bild.py ValueError when using --sym

### DIFF
--- a/pyem/util/util.py
+++ b/pyem/util/util.py
@@ -41,6 +41,7 @@ def relion_symmetry_group(sym):
     stdout = subprocess.getoutput(
         "%s --sym %s --i /dev/null --o /dev/null --print_symmetry_ops" % (relion, sym))
     lines = stdout.split("\n")[2:]
+    lines = [l for l in lines if not l.lstrip().startswith("Euler angles:")]
     return [np.array(
         [[np.double(val) for val in l.split()] for l in lines[i:i + 3]])
         for i in range(1, len(lines), 4)]


### PR DESCRIPTION
This commit fixes star2bild.py ValueError when using --sym (Issue #65 ).

As of RELION v3.1.0, relion_refine --print_symmetry_ops also prints Euler angles to the stdout,

3dem/relion@5997001f75abd0f1fa135ee25e04f92c855e5e29

This PR removes the Euler angles lines from the relion output thus avoids the ValueError.