### PR TITLE
Additional fixes for #70

### DIFF
--- a/pyem/metadata.py
+++ b/pyem/metadata.py
@@ -345,6 +345,10 @@ def cryosparc_2_cs_model_parameters(cs, df=None, minphic=0):
         log.info("Assigning pose from 2D classes")
         log.info("Assigning skew angle from 2D classification")
         model["pose"] = star.Relion.ANGLEPSI
+        for k in model:
+            if model[k] is not None:
+                name = "alignments2D/" + k
+                df[model[k]] = pd.DataFrame(cs[name])
     else:
         log.info("Particle poses not found")
     return df

--- a/pyem/metadata.py
+++ b/pyem/metadata.py
@@ -327,7 +327,7 @@ def cryosparc_2_cs_model_parameters(cs, df=None, minphic=0):
         log.info("Assigning pose from single 3D refinement")
         for k in model:
             if model[k] is not None:
-                name = phic_names[0].replace("class_posterior", k)
+                name = "alignments3D/" + k
                 df[model[k]] = pd.DataFrame(cs[name])
     elif len(phic_names) > 1:
         log.info("Assigning pose from most likely 3D classes")


### PR DESCRIPTION
If an input cs file contains both alignments2D and alignments3D, the line 331 still raises ValueError because phic_names[0] can be alignments2D/class_posterior.
https://github.com/asarnow/pyem/blob/53c98e3f3fb2caeaf318e4de9dd640e5ba521acf/pyem/metadata.py#L330-L331

This can be fixed by the first commit ( kttn8769/pyem@8696fe6 ) in this PR.

Or if an input cs file contains only alignments2D, no alignment parameter is assigned to the df.
https://github.com/asarnow/pyem/blob/53c98e3f3fb2caeaf318e4de9dd640e5ba521acf/pyem/metadata.py#L344-L349

This can be fixed by the second commit ( kttn8769/pyem@8457c53 ) in this PR.