### PR TITLE
Bugfix: Zernike CTF parameters

### DIFF
--- a/pyem/star.py
+++ b/pyem/star.py
@@ -622,12 +622,12 @@ def simplify_star_ucsf(df, resort_index=False, inplace=True, drop=True):
         df[Relion.IMAGE_NAME] = df[UCSF.IMAGE_INDEX].map(
             lambda x: "%.6d" % (x + 1)).str.cat(df[UCSF.IMAGE_PATH], sep="@")
 
-    if UCSF.ZERNIKE_COEFS_ODD in df:
+    if pd.Series(UCSF.ZERNIKE_COEFS_ODD).isin(df.columns).all():
         df[Relion.ODDZERNIKE] = df[UCSF.ZERNIKE_COEFS_ODD].astype(str).agg(",".join, axis=1)
         if drop:
             df.drop(UCSF.ZERNIKE_COEFS_ODD, axis=1, inplace=True)
 
-    if UCSF.ZERNIKE_COEFS_EVEN in df:
+    if pd.Series(UCSF.ZERNIKE_COEFS_EVEN).isin(df.columns).all():
         df[Relion.EVENZERNIKE] = df[UCSF.ZERNIKE_COEFS_EVEN].astype(str).agg(",".join, axis=1)
         if drop:
             df.drop(UCSF.ZERNIKE_COEFS_EVEN, axis=1, inplace=True)


### PR DESCRIPTION
I found a small bug in `pyem/star.py`, where it tries to check if the Zernike coefficients are included as a column in the dataframe.

The fix is pretty easy. According to [this stackoverflow question](https://stackoverflow.com/questions/47815140/check-if-multiple-columns-exist-in-a-df) the way to check if a pandas dataframe contains multiple columns is to use the pandas `.isin()` method, eg: ` pd.Series(['A', 'B']).isin(df.columns).all()`. 

So that's what I've done here.
Here's some example output from a .star file I converted with this branch. The individual terms in `_rlnOddZernike` (and `_rlnEvenZernike`) are separated by commas (but no spaces). A single space separates each column in the data optics table.
```
data_optics

loop_
_rlnVoltage #1 
_rlnImagePixelSize #2 
_rlnSphericalAberration #3 
_rlnAmplitudeContrast #4 
_rlnBeamTiltX #5 
_rlnBeamTiltY #6 
_rlnOpticsGroup #7 
_rlnImageSize #8 
_rlnMagMat00 #9 
_rlnMagMat01 #10 
_rlnMagMat10 #11 
_rlnMagMat11 #12 
_rlnOddZernike #13 
_rlnEvenZernike #14 
_rlnImageDimensionality #15 
300.000000 0.650000 2.686780 0.100000 0.076775 0.032975 3 360 -0.004738 -0.005020 -0.005219 0.005668 -0.35375538,-0.13280706,-2000.8815,6496.3965,2790.1963,831.7073 -1.5370755,279.67224,16605.41,30.46631,15336.822,-49.591393,-14976486.0,6214.921,-5361.158 2
300.000000 0.650000 2.688615 0.100000 0.080809 0.029494 4 360 -0.004517 -0.004959 -0.004960 0.005799 -0.38978606,-0.13900204,-1821.8878,6842.3994,2497.3574,913.4309 -1.534837,210.5198,15697.895,-63.045483,14601.965,-2822.9922,-14986714.0,6445.5967,-3120.5176 2

data_particles
...
```

