### PR TITLE
Fix deprecation warning, must use log.warning() instead of log.warn()

### DIFF
--- a/csparc2star.py
+++ b/csparc2star.py
@@ -83,7 +83,7 @@ def main(args):
         df = star.smart_merge(df, coord_star, fields=fields, key=key)
         star.simplify_star_ucsf(df)
         if df.shape[0] != n:
-            log.warn("%d / %d particles remain after coordinate merge" % (df.shape[0], n))
+            log.warning("%d / %d particles remain after coordinate merge" % (df.shape[0], n))
 
     if args.micrograph_path is not None:
         df = star.replace_micrograph_path(df, args.micrograph_path, inplace=True)

--- a/map.py
+++ b/map.py
@@ -127,7 +127,7 @@ def main(args):
 
     if not (args.target is None and args.euler is None and args.transform is None and args.boxsize is None) \
             and vop.ismask(data) and args.spline_order != 0:
-        log.warn("Input looks like a mask, --spline-order 0 (nearest neighbor) is recommended")
+        log.warning("Input looks like a mask, --spline-order 0 (nearest neighbor) is recommended")
 
     if args.transform is not None:
         try:

--- a/pyem/metadata.py
+++ b/pyem/metadata.py
@@ -467,9 +467,9 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
         log.debug("Converting DEFOCUSANGLE from degrees to radians")
         df[star.Relion.DEFOCUSANGLE] = np.rad2deg(df[star.Relion.DEFOCUSANGLE])
     elif star.Relion.DEFOCUSV in df and star.Relion.DEFOCUSU in df:
-        log.warn("Defocus angles not found")
+        log.warning("Defocus angles not found")
     else:
-        log.warn("Defocus values not found")
+        log.warning("Defocus values not found")
 
     if star.Relion.PHASESHIFT in df:
         log.debug("Converting PHASESHIFT from degrees to radians")
@@ -501,6 +501,6 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
         log.debug("Converting ANGLEPSI from degrees to radians")
         df[star.Relion.ANGLEPSI] = np.rad2deg(df[star.Relion.ANGLEPSI])
     elif star.is_particle_star(df):
-        log.warn("Angular alignment parameters not found")
+        log.warning("Angular alignment parameters not found")
     return df
 

--- a/subparticles.py
+++ b/subparticles.py
@@ -45,7 +45,7 @@ def main(args):
         df = star.parse_star(args.input, nrows=1)
         args.apix = star.calculate_apix(df)
         if args.apix is None:
-            log.warn("Could not compute pixel size, default is 1.0 Angstroms per pixel")
+            log.warning("Could not compute pixel size, default is 1.0 Angstroms per pixel")
             args.apix = 1.0
             df[star.Relion.MAGNIFICATION] = 10000
             df[star.Relion.DETECTORPIXELSIZE] = 1.0
@@ -70,7 +70,7 @@ def main(args):
 
     if args.transform is not None and not hasattr(args.transform, "dtype"):
         if args.target is not None:
-            log.warn("--target supersedes --transform")
+            log.warning("--target supersedes --transform")
         try:
             args.transform = np.array(json.loads(args.transform))
         except:
@@ -79,7 +79,7 @@ def main(args):
 
     if args.origin is not None:
         if args.boxsize is not None:
-            log.warn("--origin supersedes --boxsize")
+            log.warning("--origin supersedes --boxsize")
         try:
             args.origin = np.array([np.double(tok) for tok in args.origin.split(",")])
             args.origin /= args.apix
@@ -95,7 +95,7 @@ def main(args):
     df = star.parse_star(args.input)
 
     if star.calculate_apix(df) != args.apix:
-        log.warn("Using specified pixel size of %f instead of calculated size %f" %
+        log.warning("Using specified pixel size of %f instead of calculated size %f" %
                  (args.apix, star.calculate_apix(df)))
 
     if args.cls is not None:


### PR DESCRIPTION
I've been getting a deprecation warning whenever I run `csparc2star.py`. The old `log.warn()` is being deprecated, and needs to be updated to `log.warning()`

It's a minor annoyance, but the fix is pretty simple so I thought I'd do it here. There were only a few places that needed updating. 