### PR TITLE
Use psi priori for filament angles

### DIFF
--- a/pyem/metadata/cryosparc2.py
+++ b/pyem/metadata/cryosparc2.py
@@ -201,7 +201,8 @@ def cryosparc_2_cs_filament_parameters(cs, df=None):
         df = pd.DataFrame()
     if 'filament/filament_pose' in cs.dtype.names:
         log.info('Copying filament pose')
-        df[star.Relion.ANGLEPSI] = -cs['filament/filament_pose'] + np.pi/2
+        df[star.Relion.ANGLEPSIPRIOR] = np.rad2deg(-cs['filament/filament_pose'] + np.pi/2)
+        df[star.Relion.ANGLETILTPRIOR] = 90
     return df
 
 

--- a/pyem/metadata/cryosparc2.py
+++ b/pyem/metadata/cryosparc2.py
@@ -201,7 +201,7 @@ def cryosparc_2_cs_filament_parameters(cs, df=None):
         df = pd.DataFrame()
     if 'filament/filament_pose' in cs.dtype.names:
         log.info('Copying filament pose')
-        df[star.Relion.ANGLEPSIPRIOR] = np.rad2deg(-cs['filament/filament_pose'] + np.pi/2)
+        df[star.Relion.ANGLEPSIPRIOR] = np.rad2deg(-cs['filament/filament_pose'])
         df[star.Relion.ANGLETILTPRIOR] = 90
     return df
 

--- a/pyem/star.py
+++ b/pyem/star.py
@@ -45,6 +45,8 @@ class Relion:
     ANGLEROT = "rlnAngleRot"
     ANGLETILT = "rlnAngleTilt"
     ANGLEPSI = "rlnAnglePsi"
+    ANGLETILTPRIOR = "rlnAngleTiltPrior"
+    ANGLEPSIPRIOR = "rlnAnglePsiPrior"
     CLASS = "rlnClassNumber"
     DEFOCUSU = "rlnDefocusU"
     DEFOCUSV = "rlnDefocusV"


### PR DESCRIPTION
Previously (#60), I added logic for retaining info from filament angles. However, I was supposed to use the `rlnAnglePsiPrior` column, rather than the `Psi` directly. Due to this, if one had a subsequent 3D refinement, the `Psi` angle was being overwritten by the filament angles.

This PR is fixing this. Note that since the angle is no longer undergoing euler conversion at the bottom of the file, the conversion logic is slightly different (or maybe things have changed from a previous version? Either way, this now gives me priors that are almost equal to the post-refinement Psi, so they're correct).

I also added a prior of `90` to the tilt, since that's the default in relion (and cryosparc) when starting with filaments, and these two columns are typically found together.