### PR TITLE
Fix(parse cs): Remove '>' char from path fields

### DIFF
--- a/pyem/metadata/cryosparc2.py
+++ b/pyem/metadata/cryosparc2.py
@@ -69,6 +69,14 @@ movie = {u'movie_blob/path': star.Relion.MICROGRAPHMOVIE_NAME,
          u'rigid_motion/frame_end': star.Relion.MICROGRAPHENDFRAME,
          u'mscope_params/total_dose_e_per_A2': star.Relion.MICROGRAPHDOSERATE}
 
+path_fields = [
+    u'micrograph_blob/path',
+    u'movie_blob/path',
+    u'gain_ref_blob/path',
+    u'blob/path',
+    u'location/micrograph_path'
+]
+
 
 def cryosparc_2_cs_particle_locations(cs, df=None, swapxy=True, invertx=False, inverty=True):
     log = logging.getLogger('root')
@@ -357,4 +365,13 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
         df[star.Relion.ANGLEPSI] = np.rad2deg(df[star.Relion.ANGLEPSI])
     elif star.is_particle_star(df):
         log.warning("Angular alignment parameters not found")
+
+    # for cases where the incoming .cs file was exported by CryoSPARC
+    star_path_fields = [star_field for star_field in
+                        [micrograph.get(key) or general.get(key) or movie.get(key) for key in path_fields]
+                        if star_field is not None]
+    for path_field in star_path_fields:
+        if path_field in df:
+            df[path_field] = df[path_field].apply(lambda x: x.replace('>', '', 1))
+
     return df

--- a/pyem/metadata/cryosparc2.py
+++ b/pyem/metadata/cryosparc2.py
@@ -69,14 +69,6 @@ movie = {u'movie_blob/path': star.Relion.MICROGRAPHMOVIE_NAME,
          u'rigid_motion/frame_end': star.Relion.MICROGRAPHENDFRAME,
          u'mscope_params/total_dose_e_per_A2': star.Relion.MICROGRAPHDOSERATE}
 
-path_fields = [
-    u'micrograph_blob/path',
-    u'movie_blob/path',
-    u'gain_ref_blob/path',
-    u'blob/path',
-    u'location/micrograph_path'
-]
-
 
 def cryosparc_2_cs_particle_locations(cs, df=None, swapxy=True, invertx=False, inverty=True):
     log = logging.getLogger('root')
@@ -367,11 +359,10 @@ def parse_cryosparc_2_cs(csfile, passthroughs=None, minphic=0, boxsize=None,
         log.warning("Angular alignment parameters not found")
 
     # for cases where the incoming .cs file was exported by CryoSPARC
-    star_path_fields = [star_field for star_field in
-                        [micrograph.get(key) or general.get(key) or movie.get(key) for key in path_fields]
-                        if star_field is not None]
-    for path_field in star_path_fields:
+    for path_field in [*star.Relion.PATH_FIELDS, *star.UCSF.PATH_FIELDS]:
         if path_field in df:
-            df[path_field] = df[path_field].apply(lambda x: x.replace('>', '', 1))
+            if '>' in df[path_field].iloc[0]:
+                df[path_field] = df[path_field].apply(lambda x: x.replace('>', '', 1))
+                log.debug(f"Removed '>' from paths in field {path_field}")
 
     return df

--- a/pyem/star.py
+++ b/pyem/star.py
@@ -144,6 +144,8 @@ class Relion:
                         MAGMAT00, MAGMAT01, MAGMAT10, MAGMAT11, IMAGEPIXELSIZE, IMAGESIZE, IMAGEDIMENSION,
                         MICROGRAPHPIXELSIZE, MICROGRAPHORIGINALPIXELSIZE]
 
+    PATH_FIELDS = [MICROGRAPH_NAME, MICROGRAPHMOVIE_NAME, MICROGRAPHGAIN_NAME]
+
     # Data tables.
     GENERALDATA = "data_general"
     OPTICDATA = "data_optics"
@@ -186,6 +188,7 @@ class UCSF:
     ZERNIKE_COEFS_ODD = [Z_neg1_1, Z_1_1, Z_neg3_3, Z_neg1_3, Z_1_3, Z_3_3]
     ZERNIKE_COEFS_EVEN = [Z_0_0, Z_neg2_2, Z_0_2, Z_2_2, Z_neg4_4, Z_neg2_4, Z_0_4, Z_2_4, Z_4_4]
 
+    PATH_FIELDS = [IMAGE_PATH]
 
 def smart_merge(s1, s2, fields, key=None, left_key=None):
     if key is None:


### PR DESCRIPTION
- added a new list that includes any fields that may have paths in them
  - note that this list is not exhaustive, it only includes the path fields already defined in `cryosparc2.py`
- strategy: remove the first occurrence of the "`>`" char in each path using `str.replace()`

fixes https://github.com/asarnow/pyem/issues/102