### PR TITLE
Before converting to STAR, put refined shifts in terms of blob apix

### DIFF
--- a/pyem/cli/csparc2star.py
+++ b/pyem/cli/csparc2star.py
@@ -43,13 +43,6 @@ def main(args):
         log.info("Detected CryoSPARC 2+ .cs file")
         cs = np.load(args.input[0])
 
-        # convert shifts from alignment psize to blob psize
-        for dimension in ["alignments2D", "alignments3D"]:
-            try:
-                cs[f"{dimension}/shift"] = cs[f"{dimension}/shift"] * cs[f"{dimension}/psize_A"].reshape(-1, 1) / cs["blob/psize_A"].reshape(-1, 1)
-            except ValueError:
-                pass
-
         if args.first10k:
             cs = cs[:10000]
 

--- a/pyem/metadata/cryosparc2.py
+++ b/pyem/metadata/cryosparc2.py
@@ -145,6 +145,13 @@ def cryosparc_2_cs_model_parameters(cs, df=None, minphic=0):
     if df is None:
         df = pd.DataFrame()
     phic_names = [n for n in cs.dtype.names if "class_posterior" in n]
+    # convert shifts from alignment psize to blob psize
+    for dimension in ["alignments2D", "alignments3D"]:
+        try:
+            cs[f"{dimension}/shift"] = cs[f"{dimension}/shift"] * cs[f"{dimension}/psize_A"].reshape(-1, 1) / cs["blob/psize_A"].reshape(-1, 1)
+            cs[f"{dimension}/psize_A"] = cs["blob/psize_A"]
+        except ValueError:
+            pass
     if u'alignments3D/class_posterior' in cs.dtype.names:
         log.info("Assigning pose from single 3D refinement")
         for k in model:


### PR DESCRIPTION
This PR ensures that refined shifts are correct in STAR files created with `csparc2star.py`

[This discussion](https://discuss.cryosparc.com/t/re-import-exported-particles-yield-bad-reconstructions/15309) in our forum led to us noticing that `csparc2star.py` uses the image pixel size to convert shifts from pixels to angstroms. However, the shifts in `alignment{2D,3D}/shift` are in terms of the pixels in `alignment{2D/3D}/psize_A`, which may differ from the image pixel size if the job which refined these shifts performed on-the-fly downsampling. This results in shifts which are wrong by a factor of the ratio between the two pixel sizes.

![image](https://github.com/user-attachments/assets/7d508c0a-8c24-4226-9391-c0878e46ace7)
![image](https://github.com/user-attachments/assets/95d54517-0957-4bf1-9931-dcb8b9559229)
![image](https://github.com/user-attachments/assets/28cede02-abc1-4ea1-b7f7-df569e17931e)

(the last 0.02 Å is from all the per-particle scales being reset to 1.0)

Since we don't care about the refinement pixel size in the final star file, I took what seemed the simplest route and just converted them immediately after loading the first `.cs` file. I tested this with an exported `.cs` file and the passthrough `.cs` file from the job itself. Since it looks like `cryosparc_2_cs_model_parameters()` is never called on passthroughs I think this should always work...

The change to `star.py` fixes a separate issue in which `.star` files produced by csparc2star.py never had particle shifts because `sync_origins_from_angst()` didn't save the `_rlnOrigin{X/Y}Angst` columns and the `_rlnOrigin{X/Y}` columns were dropped as deprecated. The missing shifts then prevented CryoSPARC from importing the poses at all. Please do let me know if this isn't a bug and I missed a setting somewhere!

Thanks, and please let me know if you have any more questions or if you need me to rework it some other way!