### PR TITLE
fix: 'rU' changed to 'r' for open()

### DIFF
--- a/pyem/metadata/cistem.py
+++ b/pyem/metadata/cistem.py
@@ -28,7 +28,7 @@ def parse_f9_par(fn):
                  "Pixel size of images (A)": None}
     ln = 1
     skip = 0
-    with open(fn, 'rU') as f:
+    with open(fn, 'r') as f:
         lastheader = False
         firstblock = True
         for l in f:

--- a/pyem/metadata/cryosparc0.py
+++ b/pyem/metadata/cryosparc0.py
@@ -23,7 +23,7 @@ from pyem import star
 
 
 def parse_cryosparc_065_csv(csvfile):
-    with open(csvfile, 'rU') as f:
+    with open(csvfile, 'r') as f:
         lines = enumerate(f)
         idx = -1
         headers = None


### PR DESCRIPTION
'rU' has been removed as of python 3.11 (suggested version in Readme.md)